### PR TITLE
renovate設定の更新

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,11 +3,11 @@
     "config:recommended",
     ":assignee(hakshu25)",
     ":automergePatch",
-    ":automergeTypes"
+    ":automergeTypes",
+    ":label(renovate)"
   ],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],
-  "labels": ["renovate"],
   "minor": {
     "packageRules": [
       {

--- a/default.json
+++ b/default.json
@@ -1,8 +1,7 @@
 {
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":assignee(hakshu25)"],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],
-  "assignees": ["hakshu25"],
   "labels": ["renovate"],
   "patch": {
     "automerge": true

--- a/default.json
+++ b/default.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["every weekend"],
+  "assignees": ["hakshu25"],
+  "labels": ["renovate"],
+  "patch": {
+    "automerge": true
+  },
+  "minor": {
+    "packageRules": [
+      {
+        "matchDepTypes": ["devDependencies"],
+        "automerge": true
+      }
+    ]
+  }
+}

--- a/default.json
+++ b/default.json
@@ -4,7 +4,8 @@
     ":assignee(hakshu25)",
     ":automergePatch",
     ":automergeTypes",
-    ":label(renovate)"
+    ":label(renovate)",
+    ":maintainLockFilesMonthly"
   ],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],

--- a/default.json
+++ b/default.json
@@ -1,5 +1,10 @@
 {
-  "extends": ["config:recommended", ":assignee(hakshu25)", ":automergePatch"],
+  "extends": [
+    "config:recommended",
+    ":assignee(hakshu25)",
+    ":automergePatch",
+    ":automergeTypes"
+  ],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],
   "labels": ["renovate"],

--- a/default.json
+++ b/default.json
@@ -1,11 +1,8 @@
 {
-  "extends": ["config:recommended", ":assignee(hakshu25)"],
+  "extends": ["config:recommended", ":assignee(hakshu25)", ":automergePatch"],
   "timezone": "Asia/Tokyo",
   "schedule": ["every weekend"],
   "labels": ["renovate"],
-  "patch": {
-    "automerge": true
-  },
   "minor": {
     "packageRules": [
       {

--- a/package.json
+++ b/package.json
@@ -9,36 +9,6 @@
     "test": "yarn renovate-config-validator",
     "prepare": "husky install"
   },
-  "renovate-config": {
-    "default": {
-      "extends": [
-        "config:recommended"
-      ],
-      "timezone": "Asia/Tokyo",
-      "schedule": [
-        "every weekend"
-      ],
-      "assignees": [
-        "hakshu25"
-      ],
-      "labels": [
-        "renovate"
-      ],
-      "patch": {
-        "automerge": true
-      },
-      "minor": {
-        "packageRules": [
-          {
-            "matchDepTypes": [
-              "devDependencies"
-            ],
-            "automerge": true
-          }
-        ]
-      }
-    }
-  },
   "devDependencies": {
     "@commitlint/cli": "17.6.6",
     "@commitlint/config-conventional": "17.6.6",


### PR DESCRIPTION
- Shareable Config Presetsはdefault.json推奨になったためpackage.jsonから変更
  - https://docs.renovatebot.com/config-presets/
- renovateのDefault Presetsで置き換えられる設定は置き換え
  - https://docs.renovatebot.com/presets-default/
- オートマージ設定とlockfileメンテナンス設定を追加